### PR TITLE
rename packages to com.palantir.ls.*

### DIFF
--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/CompilerWrapper.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/CompilerWrapper.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver;
+package com.palantir.ls.groovy;
 
 import io.typefox.lsapi.Diagnostic;
 import io.typefox.lsapi.ReferenceParams;

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/CompilerWrapperProvider.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/CompilerWrapperProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver;
+package com.palantir.ls.groovy;
 
 /**
  * Holds and provides a {@link CompilerWrapper}.

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyLanguageServer.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyLanguageServer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver;
+package com.palantir.ls.groovy;
 
 import com.google.common.io.Files;
 import io.typefox.lsapi.InitializeParams;

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyLanguageServerConfig.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyLanguageServerConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver;
+package com.palantir.ls.groovy;
 
 import io.typefox.lsapi.MessageParams;
 import io.typefox.lsapi.ShowMessageRequestParams;

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyTextDocumentService.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyTextDocumentService.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver;
+package com.palantir.ls.groovy;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
-import com.palantir.groovylanguageserver.util.Ranges;
+import com.palantir.ls.util.Ranges;
 import io.typefox.lsapi.CodeActionParams;
 import io.typefox.lsapi.CodeLens;
 import io.typefox.lsapi.CodeLensParams;

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyWindowService.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyWindowService.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver;
+package com.palantir.ls.groovy;
 
 import io.typefox.lsapi.MessageParams;
 import io.typefox.lsapi.ShowMessageRequestParams;

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyWorkspaceService.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyWorkspaceService.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver;
+package com.palantir.ls.groovy;
 
 import io.typefox.lsapi.DidChangeConfigurationParams;
 import io.typefox.lsapi.DidChangeWatchedFilesParams;

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovycWrapper.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovycWrapper.java
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver;
+package com.palantir.ls.groovy;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
-import com.palantir.groovylanguageserver.util.DefaultDiagnosticBuilder;
-import com.palantir.groovylanguageserver.util.Ranges;
+import com.palantir.ls.util.DefaultDiagnosticBuilder;
+import com.palantir.ls.util.Ranges;
 import io.typefox.lsapi.Diagnostic;
 import io.typefox.lsapi.DiagnosticSeverity;
 import io.typefox.lsapi.Location;

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/LanguageServerConfig.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/LanguageServerConfig.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver;
+package com.palantir.ls.groovy;
 
 import io.typefox.lsapi.MessageParams;
 import io.typefox.lsapi.ShowMessageRequestParams;

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/SingleCompilerWrapperProvider.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/SingleCompilerWrapperProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver;
+package com.palantir.ls.groovy;
 
 import com.google.common.base.Preconditions;
 

--- a/groovy-language-server/src/main/java/com/palantir/ls/util/DefaultDiagnosticBuilder.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/util/DefaultDiagnosticBuilder.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver.util;
+package com.palantir.ls.util;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;

--- a/groovy-language-server/src/main/java/com/palantir/ls/util/Ranges.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/util/Ranges.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver.util;
+package com.palantir.ls.util;
 
 import com.google.common.base.Preconditions;
 import io.typefox.lsapi.Position;

--- a/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovyLanguageServerTest.java
+++ b/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovyLanguageServerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver;
+package com.palantir.ls.groovy;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;

--- a/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovyTextDocumentServiceTest.java
+++ b/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovyTextDocumentServiceTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver;
+package com.palantir.ls.groovy;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -24,8 +24,8 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.palantir.groovylanguageserver.util.DefaultDiagnosticBuilder;
-import com.palantir.groovylanguageserver.util.Ranges;
+import com.palantir.ls.util.DefaultDiagnosticBuilder;
+import com.palantir.ls.util.Ranges;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.typefox.lsapi.Diagnostic;
 import io.typefox.lsapi.DiagnosticSeverity;

--- a/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovycWrapperTest.java
+++ b/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovycWrapperTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver;
+package com.palantir.ls.groovy;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -25,8 +25,8 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-import com.palantir.groovylanguageserver.util.DefaultDiagnosticBuilder;
-import com.palantir.groovylanguageserver.util.Ranges;
+import com.palantir.ls.util.DefaultDiagnosticBuilder;
+import com.palantir.ls.util.Ranges;
 import io.typefox.lsapi.Diagnostic;
 import io.typefox.lsapi.DiagnosticSeverity;
 import io.typefox.lsapi.Location;

--- a/groovy-language-server/src/test/java/com/palantir/ls/util/RangesTest.java
+++ b/groovy-language-server/src/test/java/com/palantir/ls/util/RangesTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.palantir.groovylanguageserver.util;
+package com.palantir.ls.util;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;


### PR DESCRIPTION
com.palantir.groovylanguageserver -> com.palantir.ls.groovy
com.palantir.groovylanguageserver.util -> com.palantir.ls.util (not groovy-specific)

I'll rebase this after #45 goes in
