### PR TITLE
Use URIs throughout the Language Server requests and responses.

### DIFF
--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/CompilerWrapper.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/CompilerWrapper.java
@@ -21,6 +21,7 @@ import io.typefox.lsapi.FileEvent;
 import io.typefox.lsapi.ReferenceParams;
 import io.typefox.lsapi.SymbolInformation;
 import io.typefox.lsapi.TextDocumentContentChangeEvent;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -42,19 +43,19 @@ public interface CompilerWrapper {
     /**
      * Handle adding incremental changes to open files to be included in compilation.
      */
-    void handleFileChanged(Path originalFile, List<TextDocumentContentChangeEvent> contentChanges);
+    void handleFileChanged(URI originalFile, List<TextDocumentContentChangeEvent> contentChanges);
 
     /**
      * Handle removing non-saved changes to open files from compiled source files.
-     * @param originalFile the absolute file path of the original file
+     * @param originalFile the URI of the original file
      */
-    void handleFileClosed(Path originalFile);
+    void handleFileClosed(URI originalFile);
 
     /**
      * Handle saving the accumulated changes to the origin source.
-     * @param originalFile the absolute file path of the original file
+     * @param originalFile the URI of the original file
      */
-    void handleFileSaved(Path originalFile);
+    void handleFileSaved(URI originalFile);
 
     /**
      * Handles reconfiguring the compiled files in the event some files were created, changed or deleted outside of the
@@ -63,9 +64,9 @@ public interface CompilerWrapper {
     void handleChangeWatchedFiles(List<? extends FileEvent> changes);
 
     /**
-     * Returns a mapping from absolute path of source file to symbols located within these source files.
+     * Returns a mapping from the URI of source file to symbols located within these source files.
      */
-    Map<Path, Set<SymbolInformation>> getFileSymbols();
+    Map<URI, Set<SymbolInformation>> getFileSymbols();
 
     /**
      * Returns a mapping from a type name (class, interface, or enum) to symbols which reference those types.

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/CompilerWrapper.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/CompilerWrapper.java
@@ -65,7 +65,7 @@ public interface CompilerWrapper {
     /**
      * Returns a mapping from absolute path of source file to symbols located within these source files.
      */
-    Map<String, Set<SymbolInformation>> getFileSymbols();
+    Map<Path, Set<SymbolInformation>> getFileSymbols();
 
     /**
      * Returns a mapping from a type name (class, interface, or enum) to symbols which reference those types.

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyLanguageServer.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyLanguageServer.java
@@ -19,6 +19,7 @@ package com.palantir.ls.groovy;
 import com.google.common.io.Files;
 import com.palantir.ls.server.StreamLanguageServerLauncher;
 import com.palantir.ls.util.GroovyConstants;
+import com.palantir.ls.util.Uris;
 import io.typefox.lsapi.InitializeParams;
 import io.typefox.lsapi.InitializeResult;
 import io.typefox.lsapi.LanguageDescription;
@@ -32,9 +33,7 @@ import io.typefox.lsapi.services.LanguageServer;
 import io.typefox.lsapi.services.TextDocumentService;
 import io.typefox.lsapi.services.WindowService;
 import io.typefox.lsapi.services.WorkspaceService;
-import java.net.URI;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -63,12 +62,7 @@ public final class GroovyLanguageServer implements LanguageServer {
 
     @Override
     public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
-        try {
-            workspaceRoot = Paths.get(URI.create(params.getRootPath())).toAbsolutePath().normalize();
-        } catch (IllegalArgumentException e) {
-            logger.debug("Initialize rootPath was not valid URI '{}'", params.getRootPath());
-            workspaceRoot = Paths.get(params.getRootPath()).toAbsolutePath().normalize();
-        }
+        workspaceRoot = Uris.getAbsolutePath(params.getRootPath());
 
         ServerCapabilities capabilities = new ServerCapabilitiesBuilder()
                 .textDocumentSync(TextDocumentSyncKind.Incremental)

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyTextDocumentService.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyTextDocumentService.java
@@ -55,7 +55,8 @@ import io.typefox.lsapi.builders.CompletionListBuilder;
 import io.typefox.lsapi.builders.PublishDiagnosticsParamsBuilder;
 import io.typefox.lsapi.impl.CompletionListImpl;
 import io.typefox.lsapi.services.TextDocumentService;
-import java.nio.file.Path;
+import java.net.URI;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -114,11 +115,11 @@ public final class GroovyTextDocumentService implements TextDocumentService {
 
     @Override
     public CompletableFuture<List<? extends SymbolInformation>> documentSymbol(DocumentSymbolParams params) {
-        Path absoluteUri = Uris.resolveToRoot(provider.get().getWorkspaceRoot(), params.getTextDocument().getUri());
-        assertFileExists(absoluteUri);
+        URI uri = Uris.resolveToRoot(provider.get().getWorkspaceRoot(), params.getTextDocument().getUri());
+        assertFileExists(uri);
         List<SymbolInformation> symbols =
                 Optional.fromNullable(
-                        provider.get().getFileSymbols().get(absoluteUri).stream().collect(Collectors.toList()))
+                        provider.get().getFileSymbols().get(uri).stream().collect(Collectors.toList()))
                         .or(Lists.newArrayList());
         return CompletableFuture.completedFuture(symbols);
     }
@@ -160,36 +161,36 @@ public final class GroovyTextDocumentService implements TextDocumentService {
 
     @Override
     public void didOpen(DidOpenTextDocumentParams params) {
-        Path absoluteUri = Uris.resolveToRoot(provider.get().getWorkspaceRoot(), params.getTextDocument().getUri());
-        assertFileExists(absoluteUri);
+        URI uri = Uris.resolveToRoot(provider.get().getWorkspaceRoot(), params.getTextDocument().getUri());
+        assertFileExists(uri);
         publishDiagnostics(provider.get().compile());
     }
 
     @Override
     public void didChange(DidChangeTextDocumentParams params) {
-        Path absoluteUri = Uris.resolveToRoot(provider.get().getWorkspaceRoot(), params.getTextDocument().getUri());
-        assertFileExists(absoluteUri);
+        URI uri = Uris.resolveToRoot(provider.get().getWorkspaceRoot(), params.getTextDocument().getUri());
+        assertFileExists(uri);
         if (params.getContentChanges() == null || params.getContentChanges().isEmpty()) {
             throw new IllegalArgumentException(
-                    String.format("Calling didChange with no changes on uri '%s'", absoluteUri.toString()));
+                    String.format("Calling didChange with no changes on uri '%s'", uri.toString()));
         }
-        provider.get().handleFileChanged(absoluteUri, Lists.newArrayList(params.getContentChanges()));
+        provider.get().handleFileChanged(uri, Lists.newArrayList(params.getContentChanges()));
         publishDiagnostics(provider.get().compile());
     }
 
     @Override
     public void didClose(DidCloseTextDocumentParams params) {
-        Path absoluteUri = Uris.resolveToRoot(provider.get().getWorkspaceRoot(), params.getTextDocument().getUri());
-        assertFileExists(absoluteUri);
-        provider.get().handleFileClosed(absoluteUri);
+        URI uri = Uris.resolveToRoot(provider.get().getWorkspaceRoot(), params.getTextDocument().getUri());
+        assertFileExists(uri);
+        provider.get().handleFileClosed(uri);
         publishDiagnostics(provider.get().compile());
     }
 
     @Override
     public void didSave(DidSaveTextDocumentParams params) {
-        Path absoluteUri = Uris.resolveToRoot(provider.get().getWorkspaceRoot(), params.getTextDocument().getUri());
-        assertFileExists(absoluteUri);
-        provider.get().handleFileSaved(absoluteUri);
+        URI uri = Uris.resolveToRoot(provider.get().getWorkspaceRoot(), params.getTextDocument().getUri());
+        assertFileExists(uri);
+        provider.get().handleFileSaved(uri);
         publishDiagnostics(provider.get().compile());
     }
 
@@ -209,8 +210,8 @@ public final class GroovyTextDocumentService implements TextDocumentService {
         config.getPublishDiagnostics().accept(paramsBuilder.build());
     }
 
-    private void assertFileExists(Path uri) {
-        checkArgument(uri.toFile().exists(), String.format("Uri '%s' does not exist", uri));
+    private void assertFileExists(URI uri) {
+        checkArgument(Paths.get(uri).toFile().exists(), String.format("Uri '%s' does not exist", uri));
     }
 
     private static CompletionList createCompletionListFromSymbols(Set<SymbolInformation> symbols) {

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyTextDocumentService.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyTextDocumentService.java
@@ -55,8 +55,8 @@ import io.typefox.lsapi.builders.CompletionListBuilder;
 import io.typefox.lsapi.builders.PublishDiagnosticsParamsBuilder;
 import io.typefox.lsapi.impl.CompletionListImpl;
 import io.typefox.lsapi.services.TextDocumentService;
+import java.io.File;
 import java.net.URI;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -211,7 +211,7 @@ public final class GroovyTextDocumentService implements TextDocumentService {
     }
 
     private void assertFileExists(URI uri) {
-        checkArgument(Paths.get(uri).toFile().exists(), String.format("Uri '%s' does not exist", uri));
+        checkArgument(new File(uri).exists(), String.format("Uri '%s' does not exist", uri));
     }
 
     private static CompletionList createCompletionListFromSymbols(Set<SymbolInformation> symbols) {

--- a/groovy-language-server/src/main/java/com/palantir/ls/util/Uris.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/util/Uris.java
@@ -50,26 +50,17 @@ public final class Uris {
     }
 
     /**
-     * Normalizes the given URI and resolves it on the given absolutePathOfRoot if it is not already an absolute path.
-     * @throws IllegalArgumentException if absolutePathOfRoot is not an absolute path
+     * Normalizes the given URI and resolves it on the given absoluteRootPath if it is not already an absolute path.
+     * @throws IllegalArgumentException if absoluteRootPath is not an absolute path
      */
-    public static Path resolveToRoot(Path absolutePathOfRoot, String uri) {
-        checkArgument(absolutePathOfRoot.isAbsolute(), "absolutePathOfRoot must be absolute");
+    public static URI resolveToRoot(Path absoluteRootPath, String uri) {
+        checkArgument(absoluteRootPath.isAbsolute(), "absoluteRootPath must be absolute");
         if (isFileUri(uri)) {
-            return getAbsolutePath(uri);
+            return getAbsolutePath(uri).toUri();
         } else {
             Path path = Paths.get(uri).normalize();
-            return path.isAbsolute() ? path : absolutePathOfRoot.resolve(path).toAbsolutePath();
+            return path.isAbsolute() ? path.toUri() : absoluteRootPath.resolve(path).toAbsolutePath().toUri();
         }
-    }
-
-    /**
-     * Returns the given absolutePath as a file URI.
-     * @throws IllegalArgumentException if absolutePath is not an absolute path
-     */
-    public static String absolutePathAsFileUri(Path absolutePath) {
-        checkArgument(absolutePath.isAbsolute(), "absolutePath must be absolute");
-        return "file:" + absolutePath.normalize().toString();
     }
 
 }

--- a/groovy-language-server/src/main/java/com/palantir/ls/util/Uris.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/util/Uris.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.ls.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public final class Uris {
+
+    private Uris() {}
+
+    /**
+     * Returns whether the given URI is a valid file URI.
+     */
+    public static boolean isFileUri(String uri) {
+        try {
+            Paths.get(URI.create(uri));
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Returns the absolute path of the given URI.
+     */
+    public static Path getAbsolutePath(String uri) {
+        try {
+            return Paths.get(URI.create(uri)).toAbsolutePath().normalize();
+        } catch (Exception e) {
+            return Paths.get(uri).toAbsolutePath().normalize();
+        }
+    }
+
+    /**
+     * Normalizes the given URI and resolves it on the given absolutePathOfRoot if it is not already an absolute path.
+     * @throws IllegalArgumentException if absolutePathOfRoot is not an absolute path
+     */
+    public static Path resolveToRoot(Path absolutePathOfRoot, String uri) {
+        checkArgument(absolutePathOfRoot.isAbsolute(), "absolutePathOfRoot must be absolute");
+        if (isFileUri(uri)) {
+            return getAbsolutePath(uri);
+        } else {
+            Path path = Paths.get(uri).normalize();
+            return path.isAbsolute() ? path : absolutePathOfRoot.resolve(path).toAbsolutePath();
+        }
+    }
+
+    /**
+     * Returns the given absolutePath as a file URI.
+     * @throws IllegalArgumentException if absolutePath is not an absolute path
+     */
+    public static String absolutePathAsFileUri(Path absolutePath) {
+        checkArgument(absolutePath.isAbsolute(), "absolutePath must be absolute");
+        return "file:" + absolutePath.normalize().toString();
+    }
+
+}

--- a/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovyLanguageServerTest.java
+++ b/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovyLanguageServerTest.java
@@ -92,24 +92,25 @@ public final class GroovyLanguageServerTest {
 
     @Test
     public void testInitialize_relativeWorkspacePath() throws InterruptedException, ExecutionException, IOException {
-        File workspaceRoot = Paths.get("").toAbsolutePath().resolve("something").toFile();
+        File workspaceRoot = Paths.get("").toAbsolutePath().resolve("test-directory-to-be-deleted").toFile();
         // Create a directory in our working directory
+        // If this fails, make sure ./groovy-language-server/test-directory-to-be-deleted doesn't exist.
         assertTrue(workspaceRoot.mkdir());
 
         InitializeParams params =
                 new InitializeParamsBuilder().capabilities(new ClientCapabilitiesImpl()).processId(1)
-                        .rootPath("something").build();
+                        .rootPath("test-directory-to-be-deleted").build();
         InitializeResult result = server.initialize(params).get();
         assertInitializeResultIsCorrect(workspaceRoot.toPath(), result);
 
         // Test normalization
         params = new InitializeParamsBuilder().capabilities(new ClientCapabilitiesImpl()).processId(1)
-                        .rootPath("./something").build();
+                        .rootPath("./test-directory-to-be-deleted").build();
         result = server.initialize(params).get();
         assertInitializeResultIsCorrect(workspaceRoot.toPath(), result);
 
         params = new InitializeParamsBuilder().capabilities(new ClientCapabilitiesImpl()).processId(1)
-                        .rootPath("somethingelse/../something/../something").build();
+                        .rootPath("somethingelse/../something/../test-directory-to-be-deleted").build();
         result = server.initialize(params).get();
         assertInitializeResultIsCorrect(workspaceRoot.toPath(), result);
 

--- a/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovyTextDocumentServiceTest.java
+++ b/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovyTextDocumentServiceTest.java
@@ -83,7 +83,7 @@ public final class GroovyTextDocumentServiceTest {
     private Path file;
     private List<PublishDiagnosticsParams> publishedDiagnostics = Lists.newArrayList();
     private Set<Diagnostic> expectedDiagnostics = Sets.newHashSet();
-    private Map<String, Set<SymbolInformation>> symbolsMap = Maps.newHashMap();
+    private Map<Path, Set<SymbolInformation>> symbolsMap = Maps.newHashMap();
     private Set<SymbolInformation> expectedReferences = Sets.newHashSet();
 
     @Mock
@@ -102,7 +102,7 @@ public final class GroovyTextDocumentServiceTest {
         file = workspace.newFile("something.groovy").toPath();
         SymbolInformation symbol1 = new SymbolInformationBuilder().name("ThisIsASymbol").kind(SymbolKind.Field).build();
         SymbolInformation symbol2 = new SymbolInformationBuilder().name("methodA").kind(SymbolKind.Method).build();
-        symbolsMap.put(file.toAbsolutePath().toString(), Sets.newHashSet(symbol1, symbol2));
+        symbolsMap.put(file.toAbsolutePath(), Sets.newHashSet(symbol1, symbol2));
 
         expectedReferences.add(new SymbolInformationBuilder()
                 .containerName("Something")
@@ -263,7 +263,7 @@ public final class GroovyTextDocumentServiceTest {
         CompletableFuture<List<? extends SymbolInformation>> response =
                 service.documentSymbol(new DocumentSymbolParamsBuilder().textDocument(textDocument).build());
         assertThat(response.get().stream().collect(Collectors.toSet()),
-                is(symbolsMap.get(file.toAbsolutePath().toString())));
+                is(symbolsMap.get(file.toAbsolutePath())));
     }
 
     @Test
@@ -272,7 +272,7 @@ public final class GroovyTextDocumentServiceTest {
         CompletableFuture<List<? extends SymbolInformation>> response =
                 service.documentSymbol(new DocumentSymbolParamsBuilder().textDocument(textDocument).build());
         assertThat(response.get().stream().collect(Collectors.toSet()),
-                is(symbolsMap.get(file.toAbsolutePath().toString())));
+                is(symbolsMap.get(file.toAbsolutePath())));
     }
 
     @Test

--- a/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovyTextDocumentServiceTest.java
+++ b/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovyTextDocumentServiceTest.java
@@ -54,6 +54,7 @@ import io.typefox.lsapi.builders.TextDocumentItemBuilder;
 import io.typefox.lsapi.builders.TextDocumentPositionParamsBuilder;
 import io.typefox.lsapi.builders.VersionedTextDocumentIdentifierBuilder;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -80,10 +81,10 @@ public final class GroovyTextDocumentServiceTest {
     public ExpectedException expectedException = ExpectedException.none();
 
     private GroovyTextDocumentService service;
-    private Path file;
+    private Path filePath;
     private List<PublishDiagnosticsParams> publishedDiagnostics = Lists.newArrayList();
     private Set<Diagnostic> expectedDiagnostics = Sets.newHashSet();
-    private Map<Path, Set<SymbolInformation>> symbolsMap = Maps.newHashMap();
+    private Map<URI, Set<SymbolInformation>> symbolsMap = Maps.newHashMap();
     private Set<SymbolInformation> expectedReferences = Sets.newHashSet();
 
     @Mock
@@ -99,10 +100,10 @@ public final class GroovyTextDocumentServiceTest {
         expectedDiagnostics.add(new DefaultDiagnosticBuilder("Some other message", DiagnosticSeverity.Warning).build());
         Set<Diagnostic> diagnostics = Sets.newHashSet(expectedDiagnostics);
 
-        file = workspace.newFile("something.groovy").toPath();
+        filePath = workspace.newFile("something.groovy").toPath();
         SymbolInformation symbol1 = new SymbolInformationBuilder().name("ThisIsASymbol").kind(SymbolKind.Field).build();
         SymbolInformation symbol2 = new SymbolInformationBuilder().name("methodA").kind(SymbolKind.Method).build();
-        symbolsMap.put(file.toAbsolutePath(), Sets.newHashSet(symbol1, symbol2));
+        symbolsMap.put(filePath.toUri(), Sets.newHashSet(symbol1, symbol2));
 
         expectedReferences.add(new SymbolInformationBuilder()
                 .containerName("Something")
@@ -156,7 +157,7 @@ public final class GroovyTextDocumentServiceTest {
     @Test
     public void testDidOpen() {
         TextDocumentItem textDocument = new TextDocumentItemBuilder()
-                .uri(file.toAbsolutePath().toString())
+                .uri(filePath.toAbsolutePath().toString())
                 .languageId("groovy")
                 .version(1)
                 .text("something")
@@ -174,7 +175,7 @@ public final class GroovyTextDocumentServiceTest {
                 .contentChange(Ranges.createRange(0, 0, 1, 1), 3, "Hello")
                 .textDocument((VersionedTextDocumentIdentifier) new VersionedTextDocumentIdentifierBuilder()
                         .version(0)
-                        .uri(file.toAbsolutePath().toString())
+                        .uri(filePath.toAbsolutePath().toString())
                         .build())
                 .build());
         // assert diagnostics were published
@@ -187,11 +188,11 @@ public final class GroovyTextDocumentServiceTest {
     public void testDidChange_noChanges() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(
-                String.format("Calling didChange with no changes on uri '%s'", file.toAbsolutePath().toString()));
+                String.format("Calling didChange with no changes on uri '%s'", filePath.toUri()));
         service.didChange(new DidChangeTextDocumentParamsBuilder()
                 .textDocument((VersionedTextDocumentIdentifier) new VersionedTextDocumentIdentifierBuilder()
                         .version(0)
-                        .uri(file.toAbsolutePath().toString())
+                        .uri(filePath.toAbsolutePath().toString())
                         .build())
                 .build());
     }
@@ -200,11 +201,11 @@ public final class GroovyTextDocumentServiceTest {
     public void testDidChange_nonExistantUri() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException
-                .expectMessage(String.format("Uri '%s' does not exist", file.toAbsolutePath().toString() + "boo"));
+                .expectMessage(String.format("Uri '%s' does not exist", filePath.toUri() + "boo"));
         service.didChange(new DidChangeTextDocumentParamsBuilder()
                 .textDocument((VersionedTextDocumentIdentifier) new VersionedTextDocumentIdentifierBuilder()
                         .version(0)
-                        .uri(file.toAbsolutePath().toString() + "boo")
+                        .uri(filePath.toAbsolutePath().toString() + "boo")
                         .build())
                 .build());
     }
@@ -212,7 +213,7 @@ public final class GroovyTextDocumentServiceTest {
     @Test
     public void testDidClose() {
         TextDocumentIdentifier textDocument = new TextDocumentIdentifierBuilder()
-                .uri(file.toAbsolutePath().toString())
+                .uri(filePath.toAbsolutePath().toString())
                 .build();
         service.didClose(new DidCloseTextDocumentParamsBuilder().textDocument(textDocument).build());
         // assert diagnostics were published
@@ -224,18 +225,18 @@ public final class GroovyTextDocumentServiceTest {
     @Test
     public void testDidClose_nonExistantUri() {
         TextDocumentIdentifier textDocument = new TextDocumentIdentifierBuilder()
-                .uri(file.toAbsolutePath().toString() + "boo")
+                .uri(filePath.toAbsolutePath().toString() + "boo")
                 .build();
         expectedException.expect(IllegalArgumentException.class);
         expectedException
-                .expectMessage(String.format("Uri '%s' does not exist", file.toAbsolutePath().toString() + "boo"));
+                .expectMessage(String.format("Uri '%s' does not exist", filePath.toUri() + "boo"));
         service.didClose(new DidCloseTextDocumentParamsBuilder().textDocument(textDocument).build());
     }
 
     @Test
     public void testDidSave() {
         TextDocumentIdentifier textDocument = new TextDocumentIdentifierBuilder()
-                .uri(file.toAbsolutePath().toString())
+                .uri(filePath.toAbsolutePath().toString())
                 .build();
         service.didSave(new DidSaveTextDocumentParamsBuilder().textDocument(textDocument).build());
         // assert diagnostics were published
@@ -247,23 +248,23 @@ public final class GroovyTextDocumentServiceTest {
     @Test
     public void testDidSave_nonExistantUri() {
         TextDocumentIdentifier textDocument = new TextDocumentIdentifierBuilder()
-                .uri(file.toAbsolutePath().toString() + "boo")
+                .uri(filePath.toAbsolutePath().toString() + "boo")
                 .build();
         expectedException.expect(IllegalArgumentException.class);
         expectedException
-                .expectMessage(String.format("Uri '%s' does not exist", file.toAbsolutePath().toString() + "boo"));
+                .expectMessage(String.format("Uri '%s' does not exist", filePath.toUri() + "boo"));
         service.didSave(new DidSaveTextDocumentParamsBuilder().textDocument(textDocument).build());
     }
 
     @Test
     public void testDocumentSymbols_absolutePath() throws InterruptedException, ExecutionException {
         TextDocumentIdentifier textDocument = new TextDocumentIdentifierBuilder()
-                .uri(file.toAbsolutePath().toString())
+                .uri(filePath.toAbsolutePath().toString())
                 .build();
         CompletableFuture<List<? extends SymbolInformation>> response =
                 service.documentSymbol(new DocumentSymbolParamsBuilder().textDocument(textDocument).build());
         assertThat(response.get().stream().collect(Collectors.toSet()),
-                is(symbolsMap.get(file.toAbsolutePath())));
+                is(symbolsMap.get(filePath.toUri())));
     }
 
     @Test
@@ -272,17 +273,17 @@ public final class GroovyTextDocumentServiceTest {
         CompletableFuture<List<? extends SymbolInformation>> response =
                 service.documentSymbol(new DocumentSymbolParamsBuilder().textDocument(textDocument).build());
         assertThat(response.get().stream().collect(Collectors.toSet()),
-                is(symbolsMap.get(file.toAbsolutePath())));
+                is(symbolsMap.get(filePath.toUri())));
     }
 
     @Test
     public void testDocumentSymbols_nonExistantUri() throws InterruptedException, ExecutionException {
         TextDocumentIdentifier textDocument = new TextDocumentIdentifierBuilder()
-                .uri(file.toAbsolutePath().toString() + "boo")
+                .uri(filePath.toAbsolutePath().toString() + "boo")
                 .build();
         expectedException.expect(IllegalArgumentException.class);
         expectedException
-                .expectMessage(String.format("Uri '%s' does not exist", file.toAbsolutePath().toString() + "boo"));
+                .expectMessage(String.format("Uri '%s' does not exist", filePath.toUri() + "boo"));
         service.documentSymbol(new DocumentSymbolParamsBuilder().textDocument(textDocument).build());
     }
 
@@ -302,7 +303,7 @@ public final class GroovyTextDocumentServiceTest {
 
     @Test
     public void testCompletion() throws InterruptedException, ExecutionException {
-        String uri = file.toAbsolutePath().toString();
+        String uri = filePath.toAbsolutePath().toString();
         TextDocumentPositionParams params = new TextDocumentPositionParamsBuilder()
                 .position(5, 5)
                 .textDocument(uri)

--- a/groovy-language-server/src/test/java/com/palantir/ls/util/UrisTest.java
+++ b/groovy-language-server/src/test/java/com/palantir/ls/util/UrisTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.ls.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Paths;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+public final class UrisTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder root = new TemporaryFolder();
+
+    @Test
+    public void testIsFileUri() {
+        assertTrue(Uris.isFileUri("file:/var/my/path/to/something"));
+        assertTrue(Uris.isFileUri("file:/var/my/path/to/something/file.txt"));
+        assertFalse(Uris.isFileUri("/var/my/path/to/something"));
+        assertFalse(Uris.isFileUri("/var/my/path/to/something/file.txt"));
+        assertFalse(Uris.isFileUri("var/my/path/to/something"));
+        assertFalse(Uris.isFileUri("var/my/path/to/something/file.txt"));
+        // Non file
+        assertFalse(Uris.isFileUri("abc://username:password@example.com:123/path/data?key=value&key2=value2#fragid1"));
+    }
+
+    @Test
+    public void testGetAbsolutePath() {
+        String uri = "file:" + root.getRoot().getAbsolutePath();
+        String absolutePath = root.getRoot().getAbsolutePath() + "/something/somethingelse/../somethingelse/./../..";
+        assertEquals(root.getRoot().getAbsolutePath(), Uris.getAbsolutePath(uri).toString());
+        assertEquals(root.getRoot().getAbsolutePath(), Uris.getAbsolutePath(absolutePath).toString());
+    }
+
+    @Test
+    public void testResolveToRoot() {
+        String expectedPath = root.getRoot().getAbsolutePath() + "/myfile.txt";
+        String uri = "file:" + root.getRoot().getAbsolutePath() + "/myfile.txt";
+        String relativePath = "something/somethingelse/../somethingelse/./../../myfile.txt";
+        String absolutePath =
+                root.getRoot().getAbsolutePath() + "/something/somethingelse/../somethingelse/./../../myfile.txt";
+        assertEquals(expectedPath, Uris.resolveToRoot(root.getRoot().toPath(), uri).toString());
+        assertEquals(expectedPath, Uris.resolveToRoot(root.getRoot().toPath(), absolutePath).toString());
+        assertEquals(expectedPath, Uris.resolveToRoot(root.getRoot().toPath(), relativePath).toString());
+    }
+
+    @Test
+    public void testResolveToRoot_nonAbsoluteUri() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("absolutePathOfRoot must be absolute");
+        Uris.resolveToRoot(Paths.get("foo"), "foo");
+    }
+
+    @Test
+    public void testAbsolutePathAsFileUri() {
+        String expectedPath = "file:" + root.getRoot().getAbsolutePath() + "/myfile.txt";
+        String absolutePath =
+                root.getRoot().getAbsolutePath() + "/something/somethingelse/../somethingelse/./../../myfile.txt";
+        assertEquals(expectedPath, Uris.absolutePathAsFileUri(Paths.get(absolutePath)).toString());
+    }
+
+    @Test
+    public void testAbsolutePathAsFileUri_nonAbsoluteUri() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("absolutePath must be absolute");
+        Uris.absolutePathAsFileUri(Paths.get("foo"));
+    }
+
+}

--- a/groovy-language-server/src/test/java/com/palantir/ls/util/UrisTest.java
+++ b/groovy-language-server/src/test/java/com/palantir/ls/util/UrisTest.java
@@ -37,7 +37,11 @@ public final class UrisTest {
     @Test
     public void testIsFileUri() {
         assertTrue(Uris.isFileUri("file:/var/my/path/to/something"));
+        assertTrue(Uris.isFileUri("file:///var/my/path/to/something"));
+        assertTrue(Uris.isFileUri("file:////var/my/path/to/something"));
+        assertTrue(Uris.isFileUri("file://///var/my/path/to/something"));
         assertTrue(Uris.isFileUri("file:/var/my/path/to/something/file.txt"));
+        assertFalse(Uris.isFileUri("file://var/my/path/to/something"));
         assertFalse(Uris.isFileUri("/var/my/path/to/something"));
         assertFalse(Uris.isFileUri("/var/my/path/to/something/file.txt"));
         assertFalse(Uris.isFileUri("var/my/path/to/something"));
@@ -56,12 +60,14 @@ public final class UrisTest {
 
     @Test
     public void testResolveToRoot() {
-        String expectedPath = root.getRoot().getAbsolutePath() + "/myfile.txt";
-        String uri = "file:" + root.getRoot().getAbsolutePath() + "/myfile.txt";
+        String expectedPath = "file://" + root.getRoot().getAbsolutePath() + "/myfile.txt";
+        String uri1 = "file:" + root.getRoot().getAbsolutePath() + "/myfile.txt";
+        String uri2 = "file://" + root.getRoot().getAbsolutePath() + "/myfile.txt";
         String relativePath = "something/somethingelse/../somethingelse/./../../myfile.txt";
         String absolutePath =
                 root.getRoot().getAbsolutePath() + "/something/somethingelse/../somethingelse/./../../myfile.txt";
-        assertEquals(expectedPath, Uris.resolveToRoot(root.getRoot().toPath(), uri).toString());
+        assertEquals(expectedPath, Uris.resolveToRoot(root.getRoot().toPath(), uri1).toString());
+        assertEquals(expectedPath, Uris.resolveToRoot(root.getRoot().toPath(), uri2).toString());
         assertEquals(expectedPath, Uris.resolveToRoot(root.getRoot().toPath(), absolutePath).toString());
         assertEquals(expectedPath, Uris.resolveToRoot(root.getRoot().toPath(), relativePath).toString());
     }
@@ -69,23 +75,8 @@ public final class UrisTest {
     @Test
     public void testResolveToRoot_nonAbsoluteUri() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("absolutePathOfRoot must be absolute");
+        expectedException.expectMessage("absoluteRootPath must be absolute");
         Uris.resolveToRoot(Paths.get("foo"), "foo");
-    }
-
-    @Test
-    public void testAbsolutePathAsFileUri() {
-        String expectedPath = "file:" + root.getRoot().getAbsolutePath() + "/myfile.txt";
-        String absolutePath =
-                root.getRoot().getAbsolutePath() + "/something/somethingelse/../somethingelse/./../../myfile.txt";
-        assertEquals(expectedPath, Uris.absolutePathAsFileUri(Paths.get(absolutePath)).toString());
-    }
-
-    @Test
-    public void testAbsolutePathAsFileUri_nonAbsoluteUri() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("absolutePath must be absolute");
-        Uris.absolutePathAsFileUri(Paths.get("foo"));
     }
 
 }


### PR DESCRIPTION
- Allows requests to use URIs relative to the workspace root and absolute paths.

Closes #78
Closes #79
