### PR TITLE
Remove bintrayUpload constraints

### DIFF
--- a/gradle/publish-runnable.gradle
+++ b/gradle/publish-runnable.gradle
@@ -41,10 +41,6 @@ bintray {
     }
 }
 
-bintrayUpload.onlyIf {
-    project.version ==~ /\d+\.\d+\.\d+(-rc[0-9]+)?/
-}
-
 bintrayUpload.dependsOn { generatePomFileForSourcePublication }
 bintrayUpload.dependsOn { generatePomFileForShadowPublication }
 bintrayUpload.dependsOn { shadowJar }


### PR DESCRIPTION
The deployment section in circle.yml will guarantee jars won't be
uploaded unless it's a release
