### PR TITLE
Fix README.md with new repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# groovy-language-server
+# language-servers
 
-[![CircleCI](https://circleci.com/gh/palantir/groovy-language-server.svg?style=svg)](https://circleci.com/gh/palantir/groovy-language-server) [ ![Download](https://api.bintray.com/packages/palantir/releases/groovy-language-server/images/download.svg) ](https://bintray.com/palantir/releases/groovy-language-server/_latestVersion)
+[![CircleCI](https://circleci.com/gh/palantir/language-servers.svg?style=svg)](https://circleci.com/gh/palantir/language-servers) [ ![Download](https://api.bintray.com/packages/palantir/releases/groovy-language-server/images/download.svg) ](https://bintray.com/palantir/releases/groovy-language-server/_latestVersion)
 
-A groovy implementation of the [Microsoft Language Server Protocol](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md)
+A collection of implementations for the [Microsoft Language Server Protocol](https://github.com/Microsoft/language-server-protocol/blob/master/protocol.md)
 
-Uses the Java API definition in [typefox/ls-api](https://github.com/TypeFox/ls-api)
+## groovy-language-server
 
-Groovy language server is published to [bintray](https://bintray.com/palantir/releases/groovy-language-server)
+A groovy implementation of the protocol. Uses the Java API definition in [typefox/ls-api](https://github.com/TypeFox/ls-api)
 
 ## Dev setup
 - `git clone <repo link>`
-- `cd groovy-language-server`
-- `./gradlew eclipse` This generates an eclipse project
+- `cd language-servers`
+- `./gradlew eclipse` This generates eclipse projects
 - Import projects into eclipse
 
 ## Building and Testing


### PR DESCRIPTION
The build link and icon is broken so I figured might as well fix this now.

The release link will need to be fixed at the next release.
