### PR TITLE
Fix typos

### DIFF
--- a/language-server-commons/src/main/java/com/palantir/ls/services/AbstractWorkspaceService.java
+++ b/language-server-commons/src/main/java/com/palantir/ls/services/AbstractWorkspaceService.java
@@ -45,7 +45,7 @@ public abstract class AbstractWorkspaceService implements WorkspaceService {
     }
 
     @Override
-    public void didChangeConfiguraton(DidChangeConfigurationParams didChangeConfigurationParams) {
+    public void didChangeConfiguration(DidChangeConfigurationParams didChangeConfigurationParams) {
         throw new UnsupportedOperationException();
     }
 }

--- a/language-server-commons/src/test/java/com/palantir/ls/services/AbstractWorkspaceServiceTest.java
+++ b/language-server-commons/src/test/java/com/palantir/ls/services/AbstractWorkspaceServiceTest.java
@@ -65,7 +65,7 @@ public class AbstractWorkspaceServiceTest {
         }
 
         @Override
-        public void didChangeConfiguraton(DidChangeConfigurationParams didChangeConfigurationParams) {
+        public void didChangeConfiguration(DidChangeConfigurationParams didChangeConfigurationParams) {
             throw new UnsupportedOperationException();
         }
     }


### PR DESCRIPTION
The typos in ls-api is fixed, so we need to fix the typos in the
override methods too