### PR TITLE
PalantirLanguageServer#setSystemProperties

### DIFF
--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyLanguageServer.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyLanguageServer.java
@@ -19,6 +19,7 @@ package com.palantir.ls.groovy;
 import com.google.common.io.Files;
 import com.palantir.ls.DefaultCompilerWrapper;
 import com.palantir.ls.DefaultLanguageServerState;
+import com.palantir.ls.PalantirLanguageServer;
 import com.palantir.ls.StreamLanguageServerLauncher;
 import com.palantir.ls.api.LanguageServerState;
 import com.palantir.ls.api.TreeParser;
@@ -47,7 +48,7 @@ import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class GroovyLanguageServer implements LanguageServer {
+public class GroovyLanguageServer extends PalantirLanguageServer {
 
     private static final Logger logger = LoggerFactory.getLogger(GroovyLanguageServer.class);
 
@@ -145,6 +146,7 @@ public class GroovyLanguageServer implements LanguageServer {
     }
 
     public static void main(String[] args) {
+        setSystemProperties();
         LanguageServerState state = new DefaultLanguageServerState();
         LanguageServer server =
                 new GroovyLanguageServer(state, new DefaultTextDocumentService(state),

--- a/language-server-commons/src/main/java/com/palantir/ls/PalantirLanguageServer.java
+++ b/language-server-commons/src/main/java/com/palantir/ls/PalantirLanguageServer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.ls;
+
+import io.typefox.lsapi.services.LanguageServer;
+import java.util.Properties;
+
+public abstract class PalantirLanguageServer implements LanguageServer {
+    /**
+     * Call this in a language server's {@code main} function to set system properties per Palantir convention.
+     * <p>
+     * This should mimic the gradle-java-distribution plugin. */
+    protected static void setSystemProperties() {
+        Properties properties = System.getProperties();
+        properties.setProperty("java.io.tmpdir", "var/data/tmp");
+    }
+}


### PR DESCRIPTION
Introduces a standard `setSystemProperties` method for language servers to call during their startup. They can call this method to set system properties per Palantir conventions.