### PR TITLE
Refactor SourceWriter

### DIFF
--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyWorkspaceCompiler.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyWorkspaceCompiler.java
@@ -203,7 +203,8 @@ public final class GroovyWorkspaceCompiler implements WorkspaceCompiler, Supplie
     }
 
     private void addAllSourcesToCompilationUnit() {
-        // We don't include the files that have a corresponding FileBackedContentsManager since that means they will be replaced.
+        // We don't include the files that have a corresponding FileBackedContentsManager
+        // since that means they will be replaced.
         for (File file : Files.fileTreeTraverser().preOrderTraversal(workspaceRoot.toFile())) {
             String fileExtension = Files.getFileExtension(file.getAbsolutePath());
             if (!originalSourceToChangedSource.containsKey(file.toURI()) && file.isFile()
@@ -213,7 +214,8 @@ public final class GroovyWorkspaceCompiler implements WorkspaceCompiler, Supplie
         }
         // Add the replaced sources
         originalSourceToChangedSource.values()
-                .forEach(fileBackedContentsManager -> unit.addSource(fileBackedContentsManager.getDestination().toFile()));
+                .forEach(fileBackedContentsManager ->
+                        unit.addSource(fileBackedContentsManager.getDestination().toFile()));
     }
 
     private void resetCompilationUnit() {

--- a/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyWorkspaceCompiler.java
+++ b/groovy-language-server/src/main/java/com/palantir/ls/groovy/GroovyWorkspaceCompiler.java
@@ -27,8 +27,8 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Files;
 import com.palantir.ls.api.WorkspaceCompiler;
 import com.palantir.ls.groovy.util.GroovyConstants;
+import com.palantir.ls.util.FileBackedContentsManager;
 import com.palantir.ls.util.Ranges;
-import com.palantir.ls.util.SourceWriter;
 import com.palantir.ls.util.Uris;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.File;
@@ -74,7 +74,7 @@ public final class GroovyWorkspaceCompiler implements WorkspaceCompiler, Supplie
     private CompilationUnit unit;
 
     // Map from origin source filename to its changed version source writer
-    private Map<URI, SourceWriter> originalSourceToChangedSource = Maps.newHashMap();
+    private Map<URI, FileBackedContentsManager> originalSourceToChangedSource = Maps.newHashMap();
 
     private GroovyWorkspaceCompiler(Path workspaceRoot, Path changedFilesRoot, CompilerConfiguration config) {
         this.workspaceRoot = workspaceRoot;
@@ -137,18 +137,18 @@ public final class GroovyWorkspaceCompiler implements WorkspaceCompiler, Supplie
     @Override
     public void handleFileChanged(URI originalFile, List<TextDocumentContentChangeEvent> contentChanges) {
         try {
-            SourceWriter sourceWriter = null;
+            FileBackedContentsManager fileBackedContentsManager = null;
             if (originalSourceToChangedSource.containsKey(originalFile)) {
                 // New change on existing changed source
-                sourceWriter = originalSourceToChangedSource.get(originalFile);
+                fileBackedContentsManager = originalSourceToChangedSource.get(originalFile);
             } else {
                 // New source to switch out
                 Path newChangedFilePath = changedFilesRoot.resolve(workspaceRoot.relativize(Paths.get(originalFile)));
-                sourceWriter = SourceWriter.of(Paths.get(originalFile), newChangedFilePath);
-                originalSourceToChangedSource.put(originalFile, sourceWriter);
+                fileBackedContentsManager = FileBackedContentsManager.of(Paths.get(originalFile), newChangedFilePath);
+                originalSourceToChangedSource.put(originalFile, fileBackedContentsManager);
             }
             // Apply changes to source writer and reset compilation unit
-            sourceWriter.applyChanges(contentChanges);
+            fileBackedContentsManager.applyChanges(contentChanges);
             resetCompilationUnit();
         } catch (IOException e) {
             logger.error("Error occurred while handling file changes", e);
@@ -172,14 +172,9 @@ public final class GroovyWorkspaceCompiler implements WorkspaceCompiler, Supplie
 
     @Override
     public void handleFileSaved(URI originalFile) {
-        try {
-            if (originalSourceToChangedSource.containsKey(originalFile)) {
-                originalSourceToChangedSource.get(originalFile).reloadFile();
-                resetCompilationUnit();
-            }
-        } catch (IOException e) {
-            logger.error("Error occurred while handling file saved", e);
-            throw Throwables.propagate(e);
+        if (originalSourceToChangedSource.containsKey(originalFile)) {
+            originalSourceToChangedSource.get(originalFile).reload();
+            resetCompilationUnit();
         }
     }
 
@@ -208,7 +203,7 @@ public final class GroovyWorkspaceCompiler implements WorkspaceCompiler, Supplie
     }
 
     private void addAllSourcesToCompilationUnit() {
-        // We don't include the files that have a corresponding SourceWriter since that means they will be replaced.
+        // We don't include the files that have a corresponding FileBackedContentsManager since that means they will be replaced.
         for (File file : Files.fileTreeTraverser().preOrderTraversal(workspaceRoot.toFile())) {
             String fileExtension = Files.getFileExtension(file.getAbsolutePath());
             if (!originalSourceToChangedSource.containsKey(file.toURI()) && file.isFile()
@@ -218,7 +213,7 @@ public final class GroovyWorkspaceCompiler implements WorkspaceCompiler, Supplie
         }
         // Add the replaced sources
         originalSourceToChangedSource.values()
-                .forEach(sourceWriter -> unit.addSource(sourceWriter.getDestination().toFile()));
+                .forEach(fileBackedContentsManager -> unit.addSource(fileBackedContentsManager.getDestination().toFile()));
     }
 
     private void resetCompilationUnit() {

--- a/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovyLanguageServerIntegrationTest.java
+++ b/groovy-language-server/src/test/java/com/palantir/ls/groovy/GroovyLanguageServerIntegrationTest.java
@@ -298,7 +298,7 @@ public class GroovyLanguageServerIntegrationTest {
         sendDidOpen(test1);
 
         // Give it some time to publish
-        Thread.sleep(2000);
+        Thread.sleep(5000);
 
         Set<MyPublishDiagnosticParams> expectedDiagnosticsResult =
                 Sets.newHashSet(

--- a/language-server-commons/src/main/java/com/palantir/ls/api/ContentsManager.java
+++ b/language-server-commons/src/main/java/com/palantir/ls/api/ContentsManager.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.ls.api;
+
+import java.util.List;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+
+/**
+ * Manages the contents of a file.
+ */
+public interface ContentsManager {
+
+    /**
+     * Applies the specified changes to the file.
+     */
+    void applyChanges(List<TextDocumentContentChangeEvent> contentChanges);
+
+    /**
+     * Returns the current contents of the file.
+     */
+    String getContents();
+
+    /**
+     * Reloads the contents of the file from the backing store.
+     * <p>
+     * Typically, this means that any changes that have been applied via {@link #applyChanges(List)} are discarded.
+     */
+    void reload();
+
+}

--- a/language-server-commons/src/main/java/com/palantir/ls/util/InMemoryContentsManager.java
+++ b/language-server-commons/src/main/java/com/palantir/ls/util/InMemoryContentsManager.java
@@ -104,11 +104,11 @@ public final class InMemoryContentsManager implements ContentsManager {
 
         boolean endOfFile = false;
         int lastColumn = 0;
-        int i = 0;
+        int changeIndex = 0;
         int lineNum = 0;
         int currentContentsLineCount = currentContents.length;
-        for (; i < sortedChanges.size(); i++) {
-            Range range = sortedChanges.get(i).getRange();
+        for (; changeIndex < sortedChanges.size(); changeIndex++) {
+            Range range = sortedChanges.get(changeIndex).getRange();
             Position start = range.getStart();
             Position end = range.getEnd();
 
@@ -134,7 +134,7 @@ public final class InMemoryContentsManager implements ContentsManager {
             // handle the change under consideration
             String currentLine = currentContents[lineNum];
             contents.append(currentLine.substring(lastColumn, Math.min(start.getCharacter(), currentLine.length())))
-                    .append(sortedChanges.get(i).getText());
+                    .append(sortedChanges.get(changeIndex).getText());
 
             if (end.getLine() > currentContentsLineCount) {
                 break;
@@ -156,8 +156,7 @@ public final class InMemoryContentsManager implements ContentsManager {
             }
         }
 
-        List<TextDocumentContentChangeEvent> leftoverChanges = sortedChanges.subList(i,
-                sortedChanges.size());
+        List<TextDocumentContentChangeEvent> leftoverChanges = sortedChanges.subList(changeIndex, sortedChanges.size());
         leftoverChanges.forEach(change -> contents.append(change.getText()));
         if (!leftoverChanges.isEmpty()) {
             // Add a NEWLINE at the very end of the file to make it a valid file under most conventions

--- a/language-server-commons/src/main/java/com/palantir/ls/util/InMemoryContentsManager.java
+++ b/language-server-commons/src/main/java/com/palantir/ls/util/InMemoryContentsManager.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2017 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.ls.util;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.palantir.ls.api.ContentsManager;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+
+public final class InMemoryContentsManager implements ContentsManager {
+
+    private final StringBuilder contents = new StringBuilder();
+    private final Path initialContents;
+    private static final String NEWLINE = System.lineSeparator();
+
+    public InMemoryContentsManager(Path initialContents) throws IOException {
+        this.initialContents = initialContents;
+        reload();
+    }
+
+    public String getContents() {
+        return contents.toString();
+    }
+
+    @Override
+    public void reload() {
+        contents.setLength(0);
+        try {
+            contents.append(new String(Files.readAllBytes(initialContents), StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public synchronized void applyChanges(List<TextDocumentContentChangeEvent> contentChanges) {
+        // Check if any of the ranges are null
+        for (TextDocumentContentChangeEvent change : contentChanges) {
+            if (change.getRange() == null) {
+                checkArgument(contentChanges.size() == 1,
+                        "Cannot handle more than one change when a null range exists: %s",
+                        change);
+                try {
+                    handleFullReplacement(change);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+                return;
+            }
+        }
+
+        // From earliest start of range to latest
+        List<TextDocumentContentChangeEvent> sortedChanges = contentChanges.stream()
+                .parallel()
+                .sorted((c1, c2) -> Ranges.POSITION_COMPARATOR.compare(
+                        c1.getRange().getStart(),
+                        c2.getRange().getStart()))
+                .collect(Collectors.toList());
+
+        // Check if any of the ranges intersect
+        checkArgument(!Ranges.checkSortedRangesIntersect(sortedChanges.stream()
+                        .parallel()
+                        .map(TextDocumentContentChangeEvent::getRange)
+                        .collect(Collectors.toList())),
+                "Cannot apply changes with intersecting ranges in changes: %s",
+                contentChanges);
+
+        try {
+            handleChanges(sortedChanges);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private synchronized void handleFullReplacement(TextDocumentContentChangeEvent change) throws IOException {
+        contents.setLength(0);
+        contents.append(change.getText());
+    }
+
+    private synchronized void handleChanges(List<TextDocumentContentChangeEvent> sortedChanges) throws IOException {
+        String[] currentContents = contents.toString().split(NEWLINE);
+        contents.setLength(0);
+
+        boolean endOfFile = false;
+        int lastColumn = 0;
+        int i = 0;
+        int lineNum = 0;
+        int currentContentsLineCount = currentContents.length;
+        for (; i < sortedChanges.size(); i++) {
+            Range range = sortedChanges.get(i).getRange();
+            Position start = range.getStart();
+            Position end = range.getEnd();
+
+            // copy over current contents leading up to the change
+            while (start.getLine() > lineNum) {
+                if (lineNum >= currentContentsLineCount) {
+                    // this is a weird place to get into
+                    endOfFile = true;
+                    break;
+                }
+                String currentLine = currentContents[lineNum];
+                contents.append(currentLine.substring(Math.min(lastColumn, currentLine.length())))
+                        .append(NEWLINE); // aint no windows
+                lastColumn = 0;
+                lineNum++;
+            }
+
+            if (endOfFile) {
+                // this is a weird place to get into
+                break;
+            }
+
+            // handle the change under consideration
+            String currentLine = currentContents[lineNum];
+            contents.append(currentLine.substring(lastColumn, Math.min(start.getCharacter(), currentLine.length())))
+                    .append(sortedChanges.get(i).getText());
+
+            if (end.getLine() > currentContentsLineCount) {
+                break;
+            }
+            lineNum = end.getLine();
+            // Set the where the next line should start, which is where the range ends since it is exclusive.
+            lastColumn = end.getCharacter();
+        }
+
+        // any remaining content from the old contents
+        if (lineNum < currentContentsLineCount) {
+            contents.append(currentContents[lineNum].substring(Math.min(lastColumn, currentContents[lineNum].length())))
+                    .append(NEWLINE);
+            lineNum++;
+            while (lineNum < currentContentsLineCount) {
+                contents.append(currentContents[lineNum])
+                        .append(NEWLINE);
+                lineNum++;
+            }
+        }
+
+        List<TextDocumentContentChangeEvent> leftoverChanges = sortedChanges.subList(i,
+                sortedChanges.size());
+        leftoverChanges.forEach(change -> contents.append(change.getText()));
+        if (!leftoverChanges.isEmpty()) {
+            // Add a NEWLINE at the very end of the file to make it a valid file under most conventions
+            contents.append(NEWLINE);
+        }
+    }
+
+}

--- a/language-server-commons/src/test/java/com/palantir/ls/util/FileBackedContentsManagerTest.java
+++ b/language-server-commons/src/test/java/com/palantir/ls/util/FileBackedContentsManagerTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2016 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.ls.util;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+public class FileBackedContentsManagerTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder sourceFolder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryFolder destinationFolder = new TemporaryFolder();
+
+    @Test
+    public void testInitialize_noNewLine() throws IOException {
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "my file contents");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager.of(source, destination);
+        assertEquals("my file contents", FileUtils.readFileToString(source.toFile()));
+    }
+
+    @Test
+    public void testInitialize_withNewline() throws IOException {
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "my file contents\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager.of(source, destination);
+        assertEquals("my file contents\n", FileUtils.readFileToString(source.toFile()));
+        assertEquals("my file contents\n", FileUtils.readFileToString(destination.toFile()));
+    }
+
+    @Test
+    public void testDidChanges_noChanges() throws IOException {
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "first line\nsecond line\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        writer.applyChanges(changes);
+        assertEquals("first line\nsecond line\n", FileUtils.readFileToString(destination.toFile()));
+    }
+
+    @Test
+    public void testDidChanges_nullRangeChange() throws IOException {
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "first line\nsecond line\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        changes.add(new TextDocumentContentChangeEvent("foo"));
+        writer.applyChanges(changes);
+        assertEquals("foo", FileUtils.readFileToString(destination.toFile()));
+    }
+
+
+    @Test
+    public void testDidChanges_nullRangeWithMultipleChanges() throws IOException {
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "first line\nsecond line\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        changes.add(new TextDocumentContentChangeEvent("foo"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(1, 0, 1, 0), 1, "notfoo"));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format("Cannot handle more than one change when a null range exists: %s",
+                changes.get(0).toString()));
+        writer.applyChanges(changes);
+    }
+
+    @Test
+    public void testDidChanges_insertionBeginningOfLine() throws IOException {
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "first line\necond line\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(1, 0, 1, 0), 1, "s"));
+        writer.applyChanges(changes);
+        assertEquals("first line\nsecond line\n", FileUtils.readFileToString(destination.toFile()));
+    }
+
+    @Test
+    public void testDidChanges_insertionEndOfLine() throws IOException {
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "first line\nsecond line\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(1, 20, 1, 20), 13, "small change\n"));
+        writer.applyChanges(changes);
+        // Two new lines expected, one from the original contents and one from the change
+        assertEquals("first line\nsecond linesmall change\n\n", FileUtils.readFileToString(destination.toFile()));
+    }
+
+    @Test
+    public void testDidChanges_oneLineRange() throws IOException {
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "first line\nsecond line\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(0, 6, 0, 10), 12, "small change"));
+        writer.applyChanges(changes);
+        assertEquals("first small change\nsecond line\n", FileUtils.readFileToString(destination.toFile()));
+    }
+
+    @Test
+    public void testDidChanges_multiLineRange() throws IOException {
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "first line\nsecond line\nthird line\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(0, 6, 1, 6), 12, "small change"));
+        writer.applyChanges(changes);
+        assertEquals("first small change line\nthird line\n", FileUtils.readFileToString(destination.toFile()));
+    }
+
+    @Test
+    public void testDidChanges_multipleRangesWholeLines() throws IOException {
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "first line\nsecond line\nthird line\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(0, 0, 0, 20), 16, "new line number 1"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(1, 0, 1, 20), 16, "new line number 2"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(2, 0, 2, 20), 16, "new line number 3"));
+        writer.applyChanges(changes);
+        assertEquals("new line number 1\nnew line number 2\nnew line number 3\n",
+                FileUtils.readFileToString(destination.toFile()));
+    }
+
+    @Test
+    public void testDidChanges_multipleRangesSpecific() throws IOException {
+        // Tests replacing the whole lines
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "first line\nsecond line\nthird line\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(0, 1, 0, 9), 16, "new line number 1"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(1, 1, 1, 10), 16, "new line number 2"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(2, 1, 2, 9), 16, "new line number 3"));
+        writer.applyChanges(changes);
+
+        assertEquals("fnew line number 1e\nsnew line number 2e\ntnew line number 3e\n",
+                FileUtils.readFileToString(destination.toFile()));
+    }
+
+    @Test
+    public void testDidChanges_beforeFile() throws IOException {
+        // Should be appended to the start of the file
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "first line\nsecond line\nthird line\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(0, 0, 0, 0), 7, "change\n"));
+        writer.applyChanges(changes);
+        assertEquals("change\nfirst line\nsecond line\nthird line\n",
+                FileUtils.readFileToString(destination.toFile()));
+    }
+
+    @Test
+    public void testDidChanges_afterFile() throws IOException {
+        // Should be appended to the end of the file
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "first line\nsecond line\nthird line\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(30, 1, 30, 1), 6, "first "));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(31, 1, 31, 1), 6, "second"));
+        writer.applyChanges(changes);
+        assertEquals("first line\nsecond line\nthird line\nfirst second\n",
+                FileUtils.readFileToString(destination.toFile()));
+    }
+
+    @Test
+    public void testDidChanges_invalidRanges() throws IOException {
+        // Should be appended to the end of the file
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "first line\nsecond line\nthird line\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(-1, 0, 0, 0), 3, "one"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(0, 0, 0, 0), 3, "two"));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException
+                .expectMessage(String.format("range1 is not valid: %s", Ranges.createRange(-1, 0, 0, 0).toString()));
+        writer.applyChanges(changes);
+    }
+
+    @Test
+    public void testDidChanges_intersectingRanges() throws IOException {
+        // Should be appended to the end of the file
+        Path source = addFileToFolder(sourceFolder.getRoot(), "myfile.txt", "first line\nsecond line\nthird line\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        Range range = Ranges.createRange(0, 0, 0, 1);
+        changes.add(new TextDocumentContentChangeEvent(range, 3, "one"));
+        changes.add(new TextDocumentContentChangeEvent(range, 3, "two"));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(
+                String.format("Cannot apply changes with intersecting ranges in changes: %s", changes));
+        writer.applyChanges(changes);
+    }
+
+    @Test
+    public void testDidChanges_rangesStartAndEndOnSameLine() throws IOException {
+        // Should be appended to the end of the file
+        Path source =
+                addFileToFolder(sourceFolder.getRoot(), "myfile.txt",
+                        "0123456789\n0123456789\n0123456789\n0123456789\n0123456789\n");
+        Path destination = destinationFolder.getRoot().toPath().resolve("myfile.txt");
+        FileBackedContentsManager writer = FileBackedContentsManager.of(source, destination);
+        List<TextDocumentContentChangeEvent> changes = Lists.newArrayList();
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(0, 0, 0, 1), 1, "a"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(0, 2, 0, 3), 1, "b"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(0, 5, 0, 7), 1, "c"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(0, 8, 1, 2), 1, "d"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(1, 4, 2, 2), 1, "e"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(2, 4, 2, 6), 1, "f"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(2, 9, 2, 9), 1, "g"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(4, 2, 4, 3), 1, "h"));
+        changes.add(new TextDocumentContentChangeEvent(Ranges.createRange(4, 3, 4, 4), 1, "i"));
+        writer.applyChanges(changes);
+        assertEquals("a1b34c7d23e23f678g9\n0123456789\n01hi456789\n",
+                FileUtils.readFileToString(destination.toFile()));
+    }
+
+    private Path addFileToFolder(File parent, String filename, String contents) throws IOException {
+        File file = Files.createFile(Paths.get(parent.getAbsolutePath(), filename)).toFile();
+        PrintWriter writer = new PrintWriter(file, StandardCharsets.UTF_8.toString());
+        writer.print(contents);
+        writer.close();
+        return file.toPath();
+    }
+
+}


### PR DESCRIPTION
Goes in after #158 

Refactors SourceWriter into an interface and provides an additional in-memory variant.

In _very naive_ testing over 10k change applications, 100x faster than the file backed variant.